### PR TITLE
Updated flutter_svg dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   
-  flutter_svg: 0.17.3+1
+  flutter_svg: ^0.17.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
After Flutter 1.17 update, using older version of flutter_svg results in compilation error.